### PR TITLE
Implement missing hooks and client services

### DIFF
--- a/src/app/profile/[username]/bookshelf/page.tsx
+++ b/src/app/profile/[username]/bookshelf/page.tsx
@@ -1,11 +1,11 @@
 // File: src/app/profile/[username]/bookshelf/page.tsx
 import { getServerSession } from 'next-auth'
 import { authOptions }      from '@/src/libs/authOptions'
-import { db }               from '@lib/db'
+import { db }               from '@libs/db'
 import BookshelfClient      from '@components/client/bookshelf/BookshelfClient'
 
 import type { UserDTO }     from '@/src/models/user.model'
-import type { BookshelfEntryDTO } from '@/src/models/bookshelf.dto'
+import type { BookshelfEntryDTO } from '@models/bookshelf-entry.model'
 
 interface BookshelfPageProps {
   params: { username: string }

--- a/src/app/profile/me/bookshelf/page.tsx
+++ b/src/app/profile/me/bookshelf/page.tsx
@@ -1,5 +1,5 @@
 // src/app/profile/me/bookshelf/page.tsx
-import { redirectToViewerProfile } from '@lib/auth/redirectToViewer';
+import { redirectToViewerProfile } from '@libs/auth/redirectToViewer';
 
 export default async function MeBookshelf() {
   return redirectToViewerProfile('/bookshelf');

--- a/src/app/profile/me/page.tsx
+++ b/src/app/profile/me/page.tsx
@@ -1,5 +1,5 @@
 // src/app/profile/me/page.tsx
-import { redirectToViewerProfile } from '@lib/auth/redirectToViewer';
+import { redirectToViewerProfile } from '@libs/auth/redirectToViewer';
 
 export default async function Me() {
   return redirectToViewerProfile();

--- a/src/components/client/bookshelf/BookShelfItem.tsx
+++ b/src/components/client/bookshelf/BookShelfItem.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import OptionsMenu          from '@components/client/ui/OptionsMenu';
 import BookCover            from '@components/server/book/BookCover';
 import BookInfo             from '@components/server/book/BookInfo';
-import type { BookshelfEntryDTO } from '@/src/models/bookshelf.dto';
+import type { BookshelfEntryDTO } from '@models/bookshelf-entry.model';
 
 interface ShelfItemProps {
   item: BookshelfEntryDTO;

--- a/src/components/client/bookshelf/BookshelfClient.tsx
+++ b/src/components/client/bookshelf/BookshelfClient.tsx
@@ -10,7 +10,7 @@ import SearchBar  from   '@components/client/ui/SearchBar';
 import ShelfItem  from   '@components/client/bookshelf/BookShelfItem';
 
 import { BookshelfService } from '@services/BookshelfService';
-import type { BookshelfEntryDTO } from '@/src/models/bookshelf.dto';
+import type { BookshelfEntryDTO } from '@models/bookshelf-entry.model';
 
 interface BookshelfClientProps {
   initialItems: BookshelfEntryDTO[];

--- a/src/components/client/post/EditPostModal.tsx
+++ b/src/components/client/post/EditPostModal.tsx
@@ -4,7 +4,7 @@
 import { useState } from 'react';
 import { Dialog } from '@headlessui/react';
 import { updatePostRequest } from '@services/client/post.service';
-import type { UpdatePostDTO } from '@/src/models/post.model';
+import type { UpdatePostDTO } from '@services/client/post.service';
 
 interface Props {
   postId: string;

--- a/src/components/client/post/partials/NewPostForm.tsx
+++ b/src/components/client/post/partials/NewPostForm.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Image from 'next/image';
 import { Button } from '@components/client/ui/Buttons';
-import type { BookshelfEntryDTO } from '@/src/models/bookshelf.dto';
+import type { BookshelfEntryDTO } from '@models/bookshelf-entry.model';
 
 export interface NewPostFormProps {
   books: BookshelfEntryDTO[];

--- a/src/components/server/ui/FeedSidebar.tsx
+++ b/src/components/server/ui/FeedSidebar.tsx
@@ -2,7 +2,7 @@
 import SidebarShell     from '@components/server/ui/SidebarShell';
 import UserSummary      from '@components/server/user/UserSummary';
 import UserSuggestions  from '@components/server/user/UserSuggestions';
-import { getViewer }    from '@lib/auth/viewer';
+import { getViewer }    from '@libs/auth/viewer';
 import type { UserDTO } from '@/src/models/user.model';
 
 interface FeedSidebarProps {

--- a/src/components/server/user/UserSuggestions.tsx
+++ b/src/components/server/user/UserSuggestions.tsx
@@ -1,7 +1,7 @@
 // File: src/components/server/user/UserSuggestions.tsx
 import { getServerSession }   from 'next-auth/next';
 import { authOptions }        from '@/src/libs/authOptions';
-import { db }             from '@lib/db';
+import { db }             from '@libs/db';
 import UserSummary            from '@components/server/user/UserSummary';
 import FollowButton           from '@components/client/ui/FollowButton';
 import type { PublicUserDTO }       from '@/src/models/user.model';

--- a/src/hooks/post/useFeedPosts.ts
+++ b/src/hooks/post/useFeedPosts.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { feedDiscover, feedFriends } from '@clients/post.client';
+import type { PostDTO } from '@models/post.model';
+
+interface Params {
+  onlyFollowing: boolean;
+  limit: number;
+  fallbackData?: PostDTO[];
+}
+
+export default function useFeedPosts({
+  onlyFollowing,
+  limit,
+  fallbackData,
+}: Params) {
+  const key = ['feed', onlyFollowing ? 'friends' : 'discover', limit] as const;
+
+  return useQuery<PostDTO[], Error, PostDTO[], typeof key>({
+    queryKey: key,
+    queryFn: () =>
+      onlyFollowing ? feedFriends(limit) : feedDiscover(limit),
+    initialData: fallbackData,
+    staleTime: 1000 * 60 * 2,
+  });
+}

--- a/src/hooks/post/useNewPost.ts
+++ b/src/hooks/post/useNewPost.ts
@@ -1,0 +1,83 @@
+import { useState, useMemo } from 'react';
+import { createPost } from '@clients/post.client';
+import type { PostCreateDTO } from '@models/post.model';
+import type { BookshelfEntryDTO } from '@models/bookshelf-entry.model';
+
+export interface UseNewPostReturn {
+  selectedBook: string;
+  handleBookSelect: (isbn: string) => void;
+  content: string;
+  setContent: (v: string) => void;
+  currentPage: number;
+  handlePageChange: (v: number) => void;
+  progress: number;
+  loading: boolean;
+  error: string | null;
+  submit: () => Promise<void>;
+}
+
+export default function useNewPost(
+  books: BookshelfEntryDTO[],
+  onSuccess?: () => void | Promise<void>,
+): UseNewPostReturn {
+  const [selectedBook, setSelectedBook] = useState('');
+  const [content, setContent] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = useMemo(
+    () => books.find(b => b.book.isbn === selectedBook),
+    [books, selectedBook],
+  );
+
+  const progress = useMemo(() => {
+    if (!selected) return 0;
+    return selected.totalPages
+      ? Math.min(100, Math.floor((currentPage / selected.totalPages) * 100))
+      : 0;
+  }, [currentPage, selected]);
+
+  const handleBookSelect = (isbn: string) => {
+    setSelectedBook(isbn);
+    const entry = books.find(b => b.book.isbn === isbn);
+    if (entry) setCurrentPage(entry.currentPage);
+  };
+
+  const handlePageChange = (v: number) => setCurrentPage(v);
+
+  const submit = async () => {
+    if (!selectedBook) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const payload: PostCreateDTO = {
+        bookIsbn: selectedBook,
+        content,
+        currentPage,
+      };
+      await createPost(payload);
+      await onSuccess?.();
+      setSelectedBook('');
+      setContent('');
+      setCurrentPage(1);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    selectedBook,
+    handleBookSelect,
+    content,
+    setContent,
+    currentPage,
+    handlePageChange,
+    progress,
+    loading,
+    error,
+    submit,
+  };
+}

--- a/src/hooks/post/usePostController.ts
+++ b/src/hooks/post/usePostController.ts
@@ -1,0 +1,68 @@
+import { useSession, signIn } from 'next-auth/react';
+import { useState } from 'react';
+import { likePost, unlikePost, isPostLiked } from '@clients/like.client';
+import { addComment } from '@clients/comment.client';
+import { deletePost } from '@clients/post.client';
+import type { PostDTO } from '@models/post.model';
+import type { CommentDTO } from '@models/comment.model';
+
+export default function usePostController(post: PostDTO) {
+  const { data: session } = useSession();
+  const isAuthenticated = !!session;
+  const isAuthor = session?.user.username === post.author.username;
+
+  const [liked, setLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState(post.likes?.length || 0);
+  const [likeLoading, setLikeLoading] = useState(false);
+  const [comments, setComments] = useState<CommentDTO[]>(post.comments || []);
+  const [commentLoading, setCommentLoading] = useState(false);
+
+  // check initial like state
+  useState(() => {
+    if (isAuthenticated) {
+      isPostLiked(post.id).then((l) => setLiked(l)).catch(() => {});
+    }
+  });
+
+  async function toggleLike() {
+    if (!isAuthenticated) return signIn();
+    setLikeLoading(true);
+    try {
+      if (liked) {
+        await unlikePost(post.id);
+        setLikeCount((c) => c - 1);
+      } else {
+        await likePost(post.id);
+        setLikeCount((c) => c + 1);
+      }
+      setLiked(!liked);
+    } finally {
+      setLikeLoading(false);
+    }
+  }
+
+  async function add(content: string) {
+    if (!isAuthenticated) return signIn();
+    setCommentLoading(true);
+    try {
+      const comment = await addComment(post.id, content);
+      setComments((c) => [...c, comment]);
+    } finally {
+      setCommentLoading(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!isAuthor) return;
+    await deletePost(post.id);
+  }
+
+  return {
+    isAuthor,
+    isAuthenticated,
+    like: { liked, likeCount, loading: likeLoading, toggleLike },
+    comments: { comments, loading: commentLoading, addComment: add },
+    requestSignIn: () => signIn(),
+    deletePost: handleDelete,
+  };
+}

--- a/src/hooks/useBookshelfOptions.ts
+++ b/src/hooks/useBookshelfOptions.ts
@@ -1,0 +1,15 @@
+import { useBookshelfEntries } from './useBookshelf';
+
+export default function useBookshelfOptions() {
+  const {
+    data = [],
+    isLoading,
+    error,
+  } = useBookshelfEntries(true);
+
+  return {
+    books: data,
+    loading: isLoading,
+    error: (error as Error | undefined)?.message || null,
+  };
+}

--- a/src/hooks/useFollowStatus.ts
+++ b/src/hooks/useFollowStatus.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import { toggleFollow } from '@clients/follow.client';
+import { useFollowContext } from '@/src/contexts/followContext';
+
+export default function useFollowStatus(
+  targetUsername: string,
+  _initialFollowers?: number,
+  _initialFollowing?: number,
+  initialIsFollowing = false,
+) {
+  const { getFollow, setFollow } = useFollowContext();
+  const [loading, setLoading] = useState(false);
+  const [isFollowing, setIsFollowing] = useState(
+    getFollow(targetUsername) ?? initialIsFollowing,
+  );
+
+  const handleToggle = async () => {
+    setLoading(true);
+    try {
+      const res = await toggleFollow(targetUsername);
+      setIsFollowing(res.following);
+      setFollow(targetUsername, res.following);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { isFollowing, loading, toggleFollow: handleToggle };
+}

--- a/src/hooks/user/useUserUpdate.ts
+++ b/src/hooks/user/useUserUpdate.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { updateUser } from '@clients/user.client';
+import type { UserDTO } from '@models/user.model';
+
+export default function useUserUpdate(initial: UserDTO) {
+  const [user, setUser] = useState<UserDTO>(initial);
+  const [editName, setEditName] = useState(initial.name);
+  const [editBio, setEditBio] = useState(initial.bio);
+  const [editAvatar, setEditAvatar] = useState(initial.avatarUrl);
+  const [isEditing, setIsEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const startEditing = () => setIsEditing(true);
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setEditName(user.name);
+    setEditBio(user.bio);
+    setEditAvatar(user.avatarUrl);
+  };
+
+  const handleNameChange = (v: string) => setEditName(v);
+  const handleBioChange = (v: string) => setEditBio(v);
+  const handleAvatarUpload = (v: string) => setEditAvatar(v);
+
+  const saveProfile = async () => {
+    setSaving(true);
+    try {
+      const updated = await updateUser(user.username, {
+        name: editName,
+        bio: editBio,
+        avatarUrl: editAvatar,
+      });
+      setUser(updated);
+      setIsEditing(false);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return {
+    user,
+    isEditing,
+    startEditing,
+    cancelEditing,
+    editName,
+    editBio,
+    editAvatar,
+    handleNameChange,
+    handleBioChange,
+    handleAvatarUpload,
+    saveProfile,
+    saving,
+  };
+}

--- a/src/services/BookshelfService.ts
+++ b/src/services/BookshelfService.ts
@@ -1,0 +1,1 @@
+export * from './client/bookshelf.service';

--- a/src/services/client/bookshelf.service.ts
+++ b/src/services/client/bookshelf.service.ts
@@ -1,0 +1,20 @@
+import { updateEntry, removeEntry } from '@clients/bookshelf.client';
+import { getBookByIsbn } from '@clients/book.client';
+
+export const BookshelfService = {
+  async update(isbn: string, { progressPct }: { progressPct: number }) {
+    const book = await getBookByIsbn(isbn);
+    const currentPage = book.pages
+      ? Math.round((book.pages * progressPct) / 100)
+      : 0;
+    return updateEntry(isbn, { currentPage });
+  },
+
+  async updateProgress(isbn: string, currentPage: number) {
+    return updateEntry(isbn, { currentPage });
+  },
+
+  async remove(isbn: string) {
+    return removeEntry(isbn);
+  },
+};

--- a/src/services/client/post.service.ts
+++ b/src/services/client/post.service.ts
@@ -1,0 +1,15 @@
+import { editPost } from '@clients/post.client';
+import type { PostDTO } from '@models/post.model';
+
+export interface UpdatePostDTO {
+  content: string;
+  progress?: number;
+}
+
+export async function updatePostRequest(
+  postId: string,
+  data: UpdatePostDTO,
+): Promise<PostDTO> {
+  const payload: any = { content: data.content };
+  return editPost(postId, payload);
+}


### PR DESCRIPTION
## Summary
- add hooks: `useBookshelfOptions`, `useFollowStatus`, `useFeedPosts`, `useNewPost`, `usePostController`, `useUserUpdate`
- add client-side services for bookshelf and post updates
- fix incorrect import aliases
- replace outdated model references

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd0686f3083309a622a7a78e1bfb4